### PR TITLE
Access control config on country, grape and area

### DIFF
--- a/src/main/java/info/mywinecellar/config/WebSecurityConfig.java
+++ b/src/main/java/info/mywinecellar/config/WebSecurityConfig.java
@@ -10,6 +10,7 @@ package info.mywinecellar.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -24,6 +25,11 @@ public class WebSecurityConfig {
 
         // Public access to login, landing, and error pages
         http.authorizeRequests().antMatchers("/", "/login", "/errorpage").permitAll();
+
+        // Logged user edit access
+        http.authorizeRequests().antMatchers(HttpMethod.POST,
+                "/country/*/edit", "/grape/*/edit", "/area/*/edit", "/region/*/edit")
+                .hasRole("USER");
 
         // Public access to countries, grapes, wines, wine reviews, tasting notes, and producers
         http.authorizeRequests().antMatchers("/d/**", "/grape/**", "/review/**", "/tastingnotes/**").permitAll();


### PR DESCRIPTION
On this pull request, I fix a few [broken access control](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) issues based on Owasp top 10 security issues.

Particularly, the following access points have been modified so that they can only be accessed by users with admin role.
- Country
- Area
- Grape

Take into consideration that there might be a few remaining endpoints with broken access.

I've created this PR with the intention of passing an assignment on my University. So it would be great if it's approved.